### PR TITLE
fix: add stroke-linecap="round" to gauge svg

### DIFF
--- a/src/lib/Gauge.scss
+++ b/src/lib/Gauge.scss
@@ -15,6 +15,7 @@
   stroke: var(--stroke-color, lightgray);
   opacity: 0.3;
   stroke-width: var(--gauge-stroke);
+  stroke-linecap: round;
 }
 
 .gauge-range-bg {

--- a/src/lib/Gauge.svelte
+++ b/src/lib/Gauge.svelte
@@ -139,14 +139,12 @@
       <path
         class="gauge-circle"
         d={calcCurvePath(radius, borderAdjusted, startAngle, stopAngle)}
-        stroke-linecap="round"
       />
 
       <!-- Value Background -->
       {#if value != undefined || $animatedValue != 0}
         <path
           class="gauge-range-bg"
-          stroke-linecap="round"
           d={calcCurvePath(
             radius,
             borderAdjusted,

--- a/src/lib/Gauge.svelte
+++ b/src/lib/Gauge.svelte
@@ -139,12 +139,14 @@
       <path
         class="gauge-circle"
         d={calcCurvePath(radius, borderAdjusted, startAngle, stopAngle)}
+        stroke-linecap="round"
       />
 
       <!-- Value Background -->
       {#if value != undefined || $animatedValue != 0}
         <path
           class="gauge-range-bg"
+          stroke-linecap="round"
           d={calcCurvePath(
             radius,
             borderAdjusted,


### PR DESCRIPTION
Hello!
The final part of the semicircle gauge was not rounded like the initial part. I believe that is a bug.
I fixed it by adding a stroke-linecap="round" in the path of the SVG.
Here is a screenshot of the before and after the fix.
Before:
![image](https://github.com/user-attachments/assets/c746ab5e-c002-42c6-9a59-dd7043823590)

After:
![image](https://github.com/user-attachments/assets/fd5fc7a0-adde-4f55-8296-54926527d981)
